### PR TITLE
Fixed default queue name for celery workers

### DIFF
--- a/roles/kernelci-monitor/templates/localsettings.py
+++ b/roles/kernelci-monitor/templates/localsettings.py
@@ -18,8 +18,7 @@ LAVA_XMLRPC_URL="https://staging.validation.linaro.org/RPC2/"
 
 # Should be defined in basic settings, but overwriting here
 # to be sure the names match
-CELERY_QUEUE_NAME="kernelci"
-CELERY_ROUTES = {"monitor.tasks.*": {"queue": CELERY_QUEUE_NAME}}
+CELERY_DEFAULT_QUEUE = "kernelci"
 
 # load secrets from a separate file
 from kernelci_monitor_secrets import *

--- a/roles/squad-lava-listener/templates/localsettings.py
+++ b/roles/squad-lava-listener/templates/localsettings.py
@@ -24,8 +24,7 @@ SQUAD_URL = "https://qa-reports.linaro.org"
 
 # Should be defined in the basic settings, but overwriting here
 # to make sure names match
-CELERY_QUEUE_NAME="lava"
-CELERY_ROUTES = {"api.tasks.*": {"queue": CELERY_QUEUE_NAME}}
+CELERY_DEFAULT_QUEUE = "lava"
 
 # load secrets from a separate file
 from squad_lava_secrets import *


### PR DESCRIPTION
The tasks from django are now dispatched to proper queues so workers can
pick them.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>