### PR TITLE
Switched to vhost based rabbitmq separation

### DIFF
--- a/roles/kernelci-monitor/tasks/main.yml
+++ b/roles/kernelci-monitor/tasks/main.yml
@@ -86,6 +86,22 @@
   args:
     chdir: "{{kernelci_monitor_install_base}}/code"
 
+- name: add rabbitmq vhost
+  rabbitmq_vhost:
+    name: /kernelci
+    state: present
+
+- name: add rabbitmq user
+  rabbitmq_user:
+    user: kernelci
+    password: kernelci
+    permissions:
+      - vhost: /kernelci
+        configure_priv: .*
+        read_priv: .*
+        write_priv: .*
+    state: present
+
 - name: collect static files
   shell: ". {{kernelci_monitor_install_base}}/environment; for var in $(cut -d = -f 1 {{kernelci_monitor_install_base}}/environment); do export $var; done; {{kernelci_monitor_install_base}}/bin/python manage.py collectstatic --no-input"
   changed_when: False

--- a/roles/kernelci-monitor/templates/localsettings.py
+++ b/roles/kernelci-monitor/templates/localsettings.py
@@ -16,10 +16,6 @@ SQUADLISTENER_API_URL="http://lava.qa-reports.linaro.org/api/pattern/"
 
 LAVA_XMLRPC_URL="https://staging.validation.linaro.org/RPC2/"
 
-# Should be defined in basic settings, but overwriting here
-# to be sure the names match
-CELERY_DEFAULT_QUEUE = "kernelci"
-
 # load secrets from a separate file
 from kernelci_monitor_secrets import *
 from linaro_ldap import *

--- a/roles/squad-lava-listener/tasks/main.yml
+++ b/roles/squad-lava-listener/tasks/main.yml
@@ -86,6 +86,22 @@
   args:
     chdir: "{{lava_listener_install_base}}/code"
 
+- name: add rabbitmq vhost
+  rabbitmq_vhost:
+    name: /lava
+    state: present
+
+- name: add rabbitmq user
+  rabbitmq_user:
+    user: lava
+    password: lava
+    permissions:
+      - vhost: /lava
+        configure_priv: .*
+        read_priv: .*
+        write_priv: .*
+    state: present
+
 - name: collect static files
   shell: ". {{lava_listener_install_base}}/environment; for var in $(cut -d = -f 1 {{lava_listener_install_base}}/environment); do export $var; done; {{lava_listener_install_base}}/bin/python manage.py collectstatic --no-input"
   changed_when: False

--- a/roles/squad-lava-listener/templates/localsettings.py
+++ b/roles/squad-lava-listener/templates/localsettings.py
@@ -22,10 +22,6 @@ LAVA_LISTENERS = [
 ]
 SQUAD_URL = "https://qa-reports.linaro.org"
 
-# Should be defined in the basic settings, but overwriting here
-# to make sure names match
-CELERY_DEFAULT_QUEUE = "lava"
-
 # load secrets from a separate file
 from squad_lava_secrets import *
 from linaro_ldap import *


### PR DESCRIPTION
After unsuccessful attempt with queue name based separation, this patch
moves to vhosts. Change was tested locally and workers receive only
'proper' tasks.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>