### PR TITLE
Moved squad-lava-listener scheme to https

### DIFF
--- a/roles/kernelci-monitor/templates/localsettings.py
+++ b/roles/kernelci-monitor/templates/localsettings.py
@@ -14,7 +14,7 @@ KERNELCI_API_URL="https://api.kernelci.org/%s/"
 KERNELCI_STORAGE_URL="https://storage.kernelci.org/"
 KERNELCI_DATE_RANGE=1
 
-SQUADLISTENER_API_URL="http://lava.qa-reports.linaro.org/api/pattern/"
+SQUADLISTENER_API_URL="https://lava.qa-reports.linaro.org/api/pattern/"
 
 LAVA_XMLRPC_URL="https://validation.linaro.org/RPC2/"
 


### PR DESCRIPTION
Due to apache settings calls made to http are redirected to https. Also
POST request change to GET in this scheme. This breaks the connection
between kernelci-monitor and squad-lava-listener. Moving the API url to
https fixes the problem.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>