### PR TITLE
systemd-journal-remote: Remove old files regularly

### DIFF
--- a/ansible/roles/master/tasks/main.yml
+++ b/ansible/roles/master/tasks/main.yml
@@ -12,3 +12,12 @@
   name: restart squad-scheduler
   when: squad_scheduler_service.changed or install_squad.changed or settings.changed or environmentfile.changed or linaro_ldap_backends.changed or install_squad_linaro_plugins.changed
   changed_when: False
+
+# It seems that journald/journalctl won't manage systemd-journal-remote's files.
+# Use a bigger hammer to keep size under control.
+- name: Remove old log files from /var/log/journal
+  cron:
+    name: Remove old log files from /var/log/journal
+    special_time: daily
+    job: /usr/bin/find /var/log/journal/ -type f -user systemd-journal-remote -mtime +14 -delete
+


### PR DESCRIPTION
Remove files older than 14 days daily.

Signed-off-by: Dan Rue <dan.rue@linaro.org>