### PR TITLE
templates/apache2.conf: add headers to qa-report hosts

### DIFF
--- a/ansible/roles/frontend/templates/apache2.conf
+++ b/ansible/roles/frontend/templates/apache2.conf
@@ -11,6 +11,14 @@
   RewriteCond %{HTTP:X-Forwarded-Proto} =http
   RewriteRule .* https://%{HTTP:Host}%{REQUEST_URI} [L,R=permanent]
 
+  # Security headers
+  Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains;"
+  Header always set X-Content-Type-Options "nosniff;"
+  Header always set Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' www.gravatar.com; style-src 'self' 'unsafe-inline'; font-src 'self';"
+
+  # Set default cache controll if there isn't any
+  Header setIfEmpty Cache-Control "no-cache"
+
   {% if master_node %}
   <Directory /var/cache/munin/www>
     Allow from all


### PR DESCRIPTION
The following headers were added in response of LSS-442:

- Cache-Control: tell browsers how to proceed regarding caching resources.

- Content-Security-Policy: tell browsers to restrict where scripts,
  css, images, etc, are loaded from. It required to use a non-recommended
  directive `'unsafe-inline'` for inline scripts and styles present in Squad.
  NOTE: any future references, e.g. gravatar user icon, will need to be added
  to this header.

- Strict-Transport-Security (HSTS): tell browsers to always use HTTPS
  for `max-age` seconds instead of HTTP.

- X-Content-Type-Options: tell browsers that all MIME types truly represents
  a resource content. This avoids MIME sniffing.