### PR TITLE
ansible: use vault-passwd for dev environment

### DIFF
--- a/ansible/deploy
+++ b/ansible/deploy
@@ -27,7 +27,7 @@ case "$@" in
         :
         ;;
     *)
-        if [ "$env" = "production" -o "$env" = "staging" ]; then
+        if [ "$env" = "production" -o "$env" = "staging" -o "$env" = "dev" ]; then
             use_vault="--vault-password-file=$basedir/vault-passwd"
         fi
         ;;


### PR DESCRIPTION
This forces the use of local `ansible-passwd` file for "dev" deploy.

See comments https://github.com/Linaro/qa-reports.linaro.org/pull/24