### PR TITLE
Add quick workers and update worker setup

### DIFF
--- a/ansible/hosts.production
+++ b/ansible/hosts.production
@@ -2,8 +2,9 @@
 qa-reports-www-0 ansible_host=35.173.242.254 master_node=1
 qa-reports-www-1 ansible_host=34.224.70.97
 [workers]
-qa-reports-worker-0 ansible_host=18.212.9.17
+qa-reports-worker-0 ansible_host=18.212.9.17 worker_type=quick
 qa-reports-worker-1 ansible_host=3.82.25.12
+qa-reports-worker-2 ansible_host=54.173.74.91
 [production:children]
 webservers
 workers

--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -2,8 +2,9 @@
 staging-qa-reports-www-0 ansible_host=3.89.92.149 master_node=1
 staging-qa-reports-www-1 ansible_host=34.230.21.47
 [workers]
-staging-qa-reports-worker-0 ansible_host=34.238.41.123
+staging-qa-reports-worker-0 ansible_host=34.238.41.123 worker_type=quick
 staging-qa-reports-worker-1 ansible_host=3.87.142.116
+staging-qa-reports-worker-2 ansible_host=18.204.202.155
 [staging:children]
 webservers
 workers

--- a/ansible/roles/worker/templates/squad-worker.service
+++ b/ansible/roles/worker/templates/squad-worker.service
@@ -7,7 +7,11 @@ User=squad
 Group=squad
 PrivateTmp=yes
 WorkingDirectory={{install_base}}
-ExecStart={{install_base}}/bin/celery -A squad worker --concurrency={{worker_concurrency}} -Q celery,reporting_queue --max-tasks-per-child=5000 --max-memory-per-child=1500000 --loglevel INFO
+{% if worker_type is defined and worker_type == 'quick' %}
+ExecStart={{install_base}}/bin/celery -A squad worker --concurrency={{worker_concurrency}} -Q core_reporting,core_postprocess,core_quick,core_notification,ci_quick,celery --max-tasks-per-child=5000 --max-memory-per-child=1500000 --loglevel INFO
+{% else %}
+ExecStart={{install_base}}/bin/celery -A squad worker --concurrency={{worker_concurrency}} -Q ci_poll,ci_fetch --max-tasks-per-child=5000 --max-memory-per-child=1500000 --loglevel INFO
+{% endif %}
 EnvironmentFile={{install_base}}/environment
 Restart=on-failure
 RestartSec=5

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,7 +2,9 @@
 
 This terraform repository stands up qa-reports.linaro.org's AWS infrastructure including:
 - webservers (2)
-- workers (2)
+- workers (3)
+  - 2 workers dedicated to 'fetch' operations
+  - 1 worker dedicated to all other operations
 - RDS database
 - load balancer
 - staging and production environments

--- a/terraform/modules/webservers/webservers.tf
+++ b/terraform/modules/webservers/webservers.tf
@@ -27,7 +27,7 @@ variable "worker_instance_type" {
 }
 variable "worker_instance_count" {
   type = "string"
-  default = "2"
+  default = "3"
 }
 
 # Calculated variables


### PR DESCRIPTION
In order to better process slow 'fetch' tasks worker setup is updated:
 - 1 worker proceses 'quick' tasks
 - 2 workers process 'slow' tasks
SQUAD is now routing tasks to different queues now. This allows to setup
workers this way to prevent blocking quick tasks with slow tasks.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>