### PR TITLE
terraform: add `worker_type` when saving ansible inventory

### DIFF
--- a/terraform/scripts/state_to_ansible_inventory.py
+++ b/terraform/scripts/state_to_ansible_inventory.py
@@ -47,7 +47,11 @@ for host in inventory["webserver"]:
     print('{} ansible_host={}{}'.format(host['name'], host['ip'], master))
 print("[workers]")
 for host in inventory["worker"]:
-    print('{} ansible_host={}'.format(host['name'], host['ip']))
+    if "worker-0" in host['name']:
+        worker_quick = ' worker_type=quick'
+    else:
+        worker_quick = ''
+    print('{} ansible_host={}{}'.format(host['name'], host['ip'], worker_quick))
 print("[{}:children]".format(environment))
 print("webservers")
 print("workers")


### PR DESCRIPTION
The `worker_quick` would be lost in the next terraform apply. This ensures that `worker_type=quick` is added to worker-0.