### PR TITLE
Move to sqs

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -6,3 +6,4 @@ setup_cloudwatch: false
 email_from: root@localhost
 admin_email: root@localhost
 worker_concurrency_formula: 'echo $(($(nproc)*1))'
+use_rabbitmq: false

--- a/ansible/group_vars/dev
+++ b/ansible/group_vars/dev
@@ -1,6 +1,7 @@
 site_name: "Linaro QA DEV"
 linaro_ldap: false
 database_is_local: true
+use_rabbitmq: true
 database_hostname: qa-reports-master.local
 database_name: squad
 database_user: squad

--- a/ansible/hosts.dev
+++ b/ansible/hosts.dev
@@ -7,6 +7,7 @@ qa-reports-worker-quick.local ansible_host=worker-quick worker_type=quick
 webservers
 workers
 [dev:vars]
+env=dev
 master_node=0
 master_hostname=qa-reports-master.local
 database_hostname=qa-reports-master.local

--- a/ansible/hosts.production
+++ b/ansible/hosts.production
@@ -9,6 +9,7 @@ qa-reports-worker-2 ansible_host=54.173.74.91
 webservers
 workers
 [production:vars]
+env=production
 master_node=0
 master_hostname=qa-reports-www-0
 database_hostname=terraform-20180420145948581500000001.cuuutnsao02n.us-east-1.rds.amazonaws.com

--- a/ansible/hosts.production
+++ b/ansible/hosts.production
@@ -1,10 +1,10 @@
 [webservers]
-qa-reports-www-0 ansible_host=35.173.242.254 master_node=1
-qa-reports-www-1 ansible_host=34.224.70.97
+qa-reports-www-0 ansible_host=54.209.85.153 master_node=1
+qa-reports-www-1 ansible_host=54.146.248.64
 [workers]
-qa-reports-worker-0 ansible_host=18.212.9.17 worker_type=quick
-qa-reports-worker-1 ansible_host=3.82.25.12
-qa-reports-worker-2 ansible_host=54.173.74.91
+qa-reports-worker-0 ansible_host=3.92.255.26 worker_type=quick
+qa-reports-worker-1 ansible_host=34.207.112.152
+qa-reports-worker-2 ansible_host=54.92.214.77
 [production:children]
 webservers
 workers

--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -9,6 +9,7 @@ staging-qa-reports-worker-2 ansible_host=18.204.202.155
 webservers
 workers
 [staging:vars]
+env=staging
 master_node=0
 master_hostname=staging-qa-reports-www-0
 database_hostname=terraform-20180223202455880900000001.cuuutnsao02n.us-east-1.rds.amazonaws.com

--- a/ansible/munin/list_sqs_queues.py
+++ b/ansible/munin/list_sqs_queues.py
@@ -1,0 +1,25 @@
+#!{{install_base}}/bin/python
+
+import boto3
+import os
+
+# ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Client.get_queue_attributes
+num_of_msgs_attr = 'ApproximateNumberOfMessages'
+
+environment = '{{env}}'
+region = 'us-east-1'
+
+def get_queue_name(queue_url):
+    queue_name = queue_url.split('/')[4]
+    return queue_name.replace('%s_' % environment, '')
+
+client = boto3.client('sqs', region_name=region)
+queues = client.list_queues(QueueNamePrefix='%s_' % environment)
+
+if 'QueueUrls' in queues.keys():
+    for queue_url in queues['QueueUrls']:
+        attrs = client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=[num_of_msgs_attr])
+        queue_name = get_queue_name(queue_url)
+        num_of_messages = attrs['Attributes'][num_of_msgs_attr]
+
+        print('%s %s' % (queue_name, num_of_messages))

--- a/ansible/munin/squad_job_count
+++ b/ansible/munin/squad_job_count
@@ -33,5 +33,5 @@ if [ "$1" = "config" ]; then
     echo 'jobs.draw AREASTACK'
 else
     printf 'jobs.value '
-    journalctl --unit squad-worker.service --no-pager --since '5m ago' | grep -c Task.*succeeded
+    journalctl --unit squad-worker.service --no-pager --since '5m ago' | grep -c Task.*succeeded || true
 fi

--- a/ansible/munin/squad_processes
+++ b/ansible/munin/squad_processes
@@ -62,7 +62,9 @@ if [ "$1" = "config" ]; then
 
     on_worker define squad_worker "SQUAD worker"
 
+    {% if use_rabbitmq %}
     on_master define rabbitmq "RabbitMQ"
+    {% endif %}
 
     define postfix Postfix
 else
@@ -78,8 +80,10 @@ else
     on_worker printf "squad_worker.value "
     on_worker count 'celery -A squad worker'
 
+    {% if use_rabbitmq %}
     on_master printf "rabbitmq.value "
     on_master count erlang.*rabbitmq
+    {% endif %}
 
     printf "postfix.value "
     count postfix/.*/master

--- a/ansible/munin/squad_queue
+++ b/ansible/munin/squad_queue
@@ -18,6 +18,10 @@
 #
 # Plugin to monitor the SQUAD job queue
 
+{% if not use_rabbitmq %}
+exit
+{% endif %}
+
 # for master node only
 if ! systemctl is-enabled --quiet squad-listener 2>/dev/null; then
     exit

--- a/ansible/munin/squad_queue
+++ b/ansible/munin/squad_queue
@@ -18,17 +18,17 @@
 #
 # Plugin to monitor the SQUAD job queue
 
-{% if not use_rabbitmq %}
-exit
-{% endif %}
-
 # for master node only
 if ! systemctl is-enabled --quiet squad-listener 2>/dev/null; then
     exit
 fi
 
 with_queues() {
+    {% if use_rabbitmq %}
     rabbitmqctl list_queues \
+    {% else %}
+    /etc/munin/plugins/list_sqs_queues.py \
+    {% endif %}
         | grep -v 'celery@\|celeryev\|Listing queues' \
         | awk "{ $@ }"
 }

--- a/ansible/roles/base/tasks/sqs.yml
+++ b/ansible/roles/base/tasks/sqs.yml
@@ -1,0 +1,9 @@
+- name: Install packages needed for SQS
+  apt: pkg={{item}} state=present update-cache=yes
+  with_items:
+    - libcurl4-openssl-dev
+
+- name: Install dependencies for Squad to work with SQS
+  command: "{{install_base}}/bin/pip install --upgrade --upgrade-strategy=only-if-needed celery[sqs]"
+  register: install_celery_sqs
+  changed_when: "'up-to-date: celery' not in install_celery_sqs.stdout"

--- a/ansible/roles/frontend/templates/squad.service
+++ b/ansible/roles/frontend/templates/squad.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SQUAD: software quality dashboard
-After=postgresql.service rabbitmq-server.service
+After=postgresql.service{% if use_rabbitmq %} rabbitmq-server.service{% endif %}
 
 [Service]
 User=squad

--- a/ansible/roles/master/templates/squad-listener.service
+++ b/ansible/roles/master/templates/squad-listener.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SQUAD: software quality dashboard (listener)
-After=postgresql.service rabbitmq-server.service
+After=postgresql.service{% if use_rabbitmq %} rabbitmq-server.service{% endif %}
 
 [Service]
 User=squad

--- a/ansible/roles/master/templates/squad-scheduler.service
+++ b/ansible/roles/master/templates/squad-scheduler.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SQUAD: software quality dashboard (scheduler)
-After=postgresql.service rabbitmq-server.service
+After=postgresql.service{% if use_rabbitmq %} rabbitmq-server.service{% endif %}
 
 [Service]
 User=squad

--- a/ansible/roles/squad/tasks/dev.yml
+++ b/ansible/roles/squad/tasks/dev.yml
@@ -1,8 +1,16 @@
-- name: Install PostgreSQL
+- name: Install PostgreSQL and RabbitMQ
   apt: pkg={{item}} state=present update-cache=yes
   when: master_node
   with_items:
     - postgresql
+    - rabbitmq-server
+
+- name: RabbitMQ config
+  when: master_node
+  template:
+    src: roles/squad/templates/rabbitmq.config
+    dest: /etc/rabbitmq/rabbitmq.config
+  notify: restart-rabbitmq
 
 - name: get PostgreSQL config file
   shell: 'find /etc/postgresql -name postgresql.conf | head -1'

--- a/ansible/roles/squad/tasks/main.yml
+++ b/ansible/roles/squad/tasks/main.yml
@@ -13,6 +13,11 @@
   when: upgrade_only is not defined
 
 - include_role:
+    name: base
+    tasks_from: sqs.yml
+  when: upgrade_only is not defined and not use_rabbitmq
+
+- include_role:
     name: squad
     tasks_from: setup_munin.yml
   when: upgrade_only is not defined

--- a/ansible/roles/squad/tasks/setup.yml
+++ b/ansible/roles/squad/tasks/setup.yml
@@ -1,16 +1,3 @@
-- name: Install message broker packages
-  apt: pkg={{item}} state=present update-cache=yes
-  when: master_node
-  with_items:
-    - rabbitmq-server
-
-- name: RabbitMQ config
-  when: master_node
-  template:
-    src: roles/squad/templates/rabbitmq.config
-    dest: /etc/rabbitmq/rabbitmq.config
-  notify: restart-rabbitmq
-
 - meta: flush_handlers
 
 - name: create virtualenv

--- a/ansible/roles/squad/tasks/setup_munin.yml
+++ b/ansible/roles/squad/tasks/setup_munin.yml
@@ -10,16 +10,17 @@
 
 - name: munin plugins for squad
   register: munin_squad_plugins
-  copy:
-    src: munin/{{item}}
-    dest: /etc/munin/plugins/{{item}}
-    owner: root
-    group: root
-    mode: 0755
+  template:
+      src: munin/{{item}}
+      dest: /etc/munin/plugins/{{item}}
+      owner: root
+      group: root
+      mode: 0755
   with_items:
     - squad_processes
     - squad_job_count
     - squad_queue
+    - list_sqs_queues.py
 
 - name: configure munin plugins for squad
   template:

--- a/ansible/roles/squad/templates/environment
+++ b/ansible/roles/squad/templates/environment
@@ -12,6 +12,8 @@ SQUAD_EMAIL_FROM=qa-reports@linaro.org
 SQUAD_ADMINS='Antonio Terceiro <antonio.terceiro@linaro.org>, Milosz Wasilewski <milosz.wasilewski@linaro.org>, Charles Oliveira <charles.oliveira@linaro.org>'
 ENV=production
 GUNICORN_CMD_ARGS="--workers 2"
+{% if use_rabbitmq %}
 SQUAD_CELERY_BROKER_URL=amqp://{{master_hostname}}
+{% endif %}
 SQUAD_BASE_URL=https://{{server_name}}
 SQUAD_HOSTNAME={{inventory_hostname}}

--- a/ansible/roles/squad/templates/environment
+++ b/ansible/roles/squad/templates/environment
@@ -10,10 +10,14 @@ SQUAD_SITE_NAME="{{site_name}}"
 SQUAD_LOG_LEVEL=DEBUG
 SQUAD_EMAIL_FROM=qa-reports@linaro.org
 SQUAD_ADMINS='Antonio Terceiro <antonio.terceiro@linaro.org>, Milosz Wasilewski <milosz.wasilewski@linaro.org>, Charles Oliveira <charles.oliveira@linaro.org>'
-ENV=production
+ENV={{env}}
 GUNICORN_CMD_ARGS="--workers 2"
 {% if use_rabbitmq %}
 SQUAD_CELERY_BROKER_URL=amqp://{{master_hostname}}
+{% else %}
+SQUAD_CELERY_BROKER_URL=sqs://
+SQUAD_CELERY_QUEUE_NAME_PREFIX={{env}}_
+SQUAD_CELERY_POLL_INTERVAL=60
 {% endif %}
 SQUAD_BASE_URL=https://{{server_name}}
 SQUAD_HOSTNAME={{inventory_hostname}}

--- a/ansible/roles/worker/templates/squad-worker.service
+++ b/ansible/roles/worker/templates/squad-worker.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SQUAD: software quality dashboard (worker)
-After=postgresql.service rabbitmq-server.service
+After=postgresql.service{% if use_rabbitmq %} rabbitmq-server.service{% endif %}
 
 [Service]
 User=squad

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -81,7 +81,6 @@ Alarm dashboard to determine why the data is not available.
 
 There are two services that cause us-east-1a availability zone to be a point of failure for us:
 - RDS is deployed to us-east-1a and multi-AZ replication is not enabled (cost will roughly double to enable it)
-- RabbitMQ runs on the webserver in us-east-1a, and is a single point of failure.
 
 ## State
 

--- a/terraform/modules/rds/rds.tf
+++ b/terraform/modules/rds/rds.tf
@@ -3,6 +3,7 @@ variable "service_name" { type = "string" }
 variable "db_host_size" { type = "string" }
 variable "rds_db_password" { type = "string" }
 variable "rds_db_storage" { type = "string" }
+variable "rds_db_max_storage" { type = "string" }
 variable "availability_zone_to_subnet_map" { type = "map" }
 variable "vpc_id" { type = "string" }
 variable "instance_security_groups" {
@@ -57,6 +58,7 @@ resource "aws_db_parameter_group" "default" {
 
 resource "aws_db_instance" "default" {
     allocated_storage = "${var.rds_db_storage}"
+    max_allocated_storage = "${var.rds_db_max_storage}"
     storage_type = "gp2" # SSD
     apply_immediately = true
     engine = "postgres"

--- a/terraform/modules/sqs/sqs.tf
+++ b/terraform/modules/sqs/sqs.tf
@@ -1,0 +1,49 @@
+variable "environment" { type = "string" }
+
+variable "role" { type = "string" }
+
+variable "region" { type = "string" }
+
+variable "queue_names" {
+  description = "Squad queues"
+  type        = "list"
+  default     = ["celery", "ci_fetch", "ci_poll", "ci_quick", "core_notification", "core_postprocess", "core_quick", "core_reporting"]
+}
+
+resource "aws_sqs_queue" "qa_reports_queue" {
+  count = "${length(var.queue_names)}"
+  name  = "${var.environment}_${var.queue_names[count.index]}"
+}
+
+# Create an IAM policy and attach it to the environment role
+# and give permissions to list queues and manage messages
+resource "aws_iam_role_policy" "sqs_manage_policy" {
+  name = "${var.environment}_sqs_manage_policy"
+  role = "${var.role}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "sqs:DeleteMessage",
+                "sqs:SendMessage",
+                "sqs:ReceiveMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl"
+            ],
+            "Resource": ["${join("\",\"", aws_sqs_queue.qa_reports_queue.*.arn)}"]
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "sqs:ListQueues",
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}

--- a/terraform/modules/webservers/webservers.tf
+++ b/terraform/modules/webservers/webservers.tf
@@ -41,7 +41,7 @@ locals {
 resource "aws_acm_certificate" "acm-cert" {
   domain_name = "${var.canonical_dns_name}"
   subject_alternative_names = ["${local.local_dns_name}"]
-  validation_method = "EMAIL"
+  validation_method = "NONE"
 }
 
 # A security group for the load balancer so it is accessible via the web

--- a/terraform/modules/webservers/webservers.tf
+++ b/terraform/modules/webservers/webservers.tf
@@ -101,27 +101,6 @@ resource "aws_security_group" "qa-reports-ec2-www" {
     cidr_blocks = ["${data.aws_subnet.oursubnets.*.cidr_block}"]
   }
 
-  # RabbitMQ clustering traffic inside local network
-  # source: https://www.rabbitmq.com/networking.html
-  ingress {
-    from_port   = 4369
-    to_port     = 4369
-    protocol    = "tcp"
-    cidr_blocks = ["${data.aws_subnet.oursubnets.*.cidr_block}"]
-  }
-  ingress {
-    from_port   = 5671
-    to_port     = 5672
-    protocol    = "tcp"
-    cidr_blocks = ["${data.aws_subnet.oursubnets.*.cidr_block}"]
-  }
-  ingress {
-    from_port   = 25672
-    to_port     = 25672
-    protocol    = "tcp"
-    cidr_blocks = ["${data.aws_subnet.oursubnets.*.cidr_block}"]
-  }
-
   # systemd remote journal (network logging)
   ingress {
     from_port   = 19532

--- a/terraform/modules/webservers/webservers.tf
+++ b/terraform/modules/webservers/webservers.tf
@@ -11,6 +11,7 @@ variable "route53_zone_id" { type = "string" }
 variable "route53_base_domain_name" { type = "string" }
 variable "canonical_dns_name" { type = "string" }
 variable "service_name" { type = "string" }
+variable "instance_profile" { type = "string" }
 
 # Optional variables
 variable "www_instance_type" {
@@ -215,7 +216,7 @@ resource "aws_instance" "qa-reports-www" {
   availability_zone = "${element(keys(var.availability_zone_to_subnet_map), count.index)}"
 
   user_data = "${file("scripts/provision.sh")}"
-  iam_instance_profile = "qa_reports_instance_profile"
+  iam_instance_profile = "${var.instance_profile}"
 
   tags {
     Name = "${var.service_name}-www-${count.index}"
@@ -273,7 +274,7 @@ resource "aws_instance" "qa-reports-worker" {
 
   # Initial host provisioning.
   user_data = "${file("scripts/provision.sh")}"
-  iam_instance_profile = "qa_reports_instance_profile"
+  iam_instance_profile = "${var.instance_profile}"
 
   tags {
     Name = "${var.service_name}-worker-${count.index}"

--- a/terraform/qa-reports.tf
+++ b/terraform/qa-reports.tf
@@ -23,6 +23,7 @@ variable "vpc_id" { type = "string" }
 variable "region" { type = "string" }
 variable "node_type" { type = "string" }
 variable "db_node_type" { type = "string" }
+variable "db_max_allocated_storage" { type = "string" }
 variable "qa_reports_db_pass_production" {
   type = "string"
   # this will cause a failure at apply time if needed but not set
@@ -162,5 +163,6 @@ module "rds" {
   rds_db_password = "${lookup(local.rds_env_db_password, var.environment, false)}"
 
   rds_db_storage = "${lookup(local.rds_env_db_storage, var.environment, false)}"
+  rds_db_max_storage = "${var.db_max_allocated_storage}"
 }
 

--- a/terraform/qa-reports.tf
+++ b/terraform/qa-reports.tf
@@ -76,6 +76,27 @@ resource "aws_iam_role" "qa_reports_role" {
     "Statement": [
         {
             "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "qa_reports_role_policy" {
+  name = "${var.environment}_qa_reports_role_policy"
+  role = "${aws_iam_role.qa_reports_role.name}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
             "Action": [
                 "cloudwatch:PutMetricData",
                 "ec2:DescribeVolumes",
@@ -100,6 +121,12 @@ resource "aws_iam_role" "qa_reports_role" {
 EOF
 }
 
+module "sqs" {
+  source = "modules/sqs"
+  environment = "${var.environment}"
+  role = "${aws_iam_role.qa_reports_role.name}"
+  region = "${var.region}"
+}
 
 module "webservers" {
   source = "modules/webservers"

--- a/terraform/scripts/provision.sh
+++ b/terraform/scripts/provision.sh
@@ -12,6 +12,9 @@ echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4XbnFOoWpbwEiX0k6YsJQteanZft5E8IuzZ
 # mwasilew's ssh key
 echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLg0a071B8RSBVYxXoGa/dMZ7jaiLdEM8tmMIg0VTFAh8xPOUIJ8HWurQdc+mq6mMtBFqKGJ5YshLEXK//CKRW+lR+2eTEpjMLfoOR7u1zxU35+lAxbVavOwEHzjaPaGypmaqwWvNdlgsg2gl5Qo7B2f9nEnHtieAW7qI/1agjorB8/I12H2H2iC7GWKptRq1wPRp2sgwq2Bk286xTOESFV+iv0tzT5GepJUexXmF69xqlkW5uznA7LV8DqPQk/5n42K8i5gMjH+ulEDTc1/aMVjjTaSIEbEsvyvhXCXa7PpCRdXT/vodKHnRUwJPu5lkX5m9WSpl6E0RdqQY/3WTn mwasilew" >> /home/ubuntu/.ssh/authorized_keys
 
+# chaws's ssh key
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLVhmQdvjaGl4vwKAi4Nq8tAcLpBy1DnGtJR57QdeZCp6t3pL8T+1e/uA/GSxgjLkj2wbsRV7/Q6CVq16/P0LA85LHAsDw2395QaoplcupZkOgZwsv+zSpX60bZjuxpzbaLSJK6xy0H6K4IulANd6olS6jV49XYsx0xIDVih7sfW4zoEOmVPMuxtpOresK0/30J0QeClvtfZgX6V6DNb5ZmpcKmv0Pxn6PmHqexK6o8TkaMDg0kh0cL6gzqhuq+deGnphEoUGuzXA1rv1ZJKtOS8Bxg0IKg5V6ugTmfHoWKhC+4zD2FWqmOdHx5WSoE5VIitgG5yF0TcSAddLKSjTv chaws" >> /home/ubuntu/.ssh/authorized_keys
+
 retry() {
     n=1
     while [ "$n" -le 10 ] && ! "$@"; do

--- a/terraform/scripts/state_to_ansible_inventory.py
+++ b/terraform/scripts/state_to_ansible_inventory.py
@@ -57,6 +57,7 @@ print("webservers")
 print("workers")
 
 print("[{}:vars]".format(environment))
+print('env={}'.format(environment))
 print('master_node=0')
 print('master_hostname={}'.format(master_hostname))
 print("database_hostname={}".format(database['name']))

--- a/terraform/scripts/state_to_ansible_inventory.py
+++ b/terraform/scripts/state_to_ansible_inventory.py
@@ -47,7 +47,11 @@ for host in inventory["webserver"]:
     print('{} ansible_host={}{}'.format(host['name'], host['ip'], master))
 print("[workers]")
 for host in inventory["worker"]:
-    print('{} ansible_host={}'.format(host['name'], host['ip']))
+    if "worker-0" in host['name']:
+        worker_quick = ' worker_type=quick'
+    else:
+        worker_quick = ''
+    print('{} ansible_host={}{}'.format(host['name'], host['ip'], worker_quick))
 print("[{}:children]".format(environment))
 print("webservers")
 print("workers")

--- a/terraform/shared.tfvars
+++ b/terraform/shared.tfvars
@@ -11,4 +11,4 @@ route53_base_domain_name = "ctt.linaro.org"
 # us-east-1, 16.04LTS, hvm:ebs-ssd
 # see https://cloud-images.ubuntu.com/locator/ec2/
 ami_id = "ami-0b383171"
-
+db_max_allocated_storage = 500


### PR DESCRIPTION
This PR tweaks lots of files, so I tried to organize the changes by commits in the following order:

* 1st: (https://github.com/Linaro/qa-reports.linaro.org/commit/8fd42bb1e71db43a3017690eab754bb272ad0199) reproduce the existing `qa_reports_instance_profile` instance profile into terraform scripts, then change their name so that there'll be one per environment
* 2nd: (https://github.com/Linaro/qa-reports.linaro.org/commit/7b59c15e6089b94d51b9de335f548ef224e5d0f1) remove terraform setup for rabbitmq and make ansible set it up only for development environments
* 3rd: (https://github.com/Linaro/qa-reports.linaro.org/commit/2f2cf904c022afae557e63754d1db242bf27b220) do the actual migration to AWS SQS
  * pre-create queues prefixed with environment name
  * attach SQS queue access to the environment role so that workers and webservers can talk to SQS without explicit credentials
  * use `list_sqs_queues.py` instead of `rabbitmqctl list_queues` so that munin can monitor number of tasks in queues

@danrue , could you help us make sure things are reasonable in terraform? I managed to understand `instance_profile` OK, but it turned out that we already had an existing one named `qa_reports_instance_profile`, I don't know who created that. I think it got it right in reproducing its permissions into terraform.

@terceiro , is it OK for `list_sqs_queues.py` to live under `/etc/munin/plugins`? I had to write our own script, since the solution we're using to authenticate to SQS would break that plugin I told you in the meeting. 

I wanted to run this in staging after we're sure of the things above.