### PR TITLE
terraform: sqs: add visibility timeout option

### DIFF
--- a/terraform/modules/sqs/sqs.tf
+++ b/terraform/modules/sqs/sqs.tf
@@ -4,6 +4,8 @@ variable "role" { type = "string" }
 
 variable "region" { type = "string" }
 
+variable "visibility_timeout" { type = "string" }
+
 variable "queue_names" {
   description = "Squad queues"
   type        = "list"
@@ -13,6 +15,7 @@ variable "queue_names" {
 resource "aws_sqs_queue" "qa_reports_queue" {
   count = "${length(var.queue_names)}"
   name  = "${var.environment}_${var.queue_names[count.index]}"
+  visibility_timeout_seconds = "${var.visibility_timeout}"
 }
 
 # Create an IAM policy and attach it to the environment role

--- a/terraform/qa-reports.tf
+++ b/terraform/qa-reports.tf
@@ -24,6 +24,7 @@ variable "region" { type = "string" }
 variable "node_type" { type = "string" }
 variable "db_node_type" { type = "string" }
 variable "db_max_allocated_storage" { type = "string" }
+variable "sqs_visibility_timeout" { type = "string" }
 variable "qa_reports_db_pass_production" {
   type = "string"
   # this will cause a failure at apply time if needed but not set
@@ -127,6 +128,7 @@ module "sqs" {
   environment = "${var.environment}"
   role = "${aws_iam_role.qa_reports_role.name}"
   region = "${var.region}"
+  visibility_timeout = "${var.sqs_visibility_timeout}"
 }
 
 module "webservers" {

--- a/terraform/shared.tfvars
+++ b/terraform/shared.tfvars
@@ -12,3 +12,7 @@ route53_base_domain_name = "ctt.linaro.org"
 # see https://cloud-images.ubuntu.com/locator/ec2/
 ami_id = "ami-0b383171"
 db_max_allocated_storage = 500
+
+# SQS visibility timeout in seconds
+# see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+sqs_visibility_timeout = 3600


### PR DESCRIPTION
This adds visibility timeout for all the queues. This means that if a task had been picked by one worker, it would go "invisible" for one 1h before other worker can fetch it from SQS.

There are two main reasons for that:
* 1. tasks with ETA: workers picked these tasks, checked that there is nothing to do (due to ETA), and would pick the same tasks again. We think that workers should pick unique tasks only once, but that's not what was happening in practice. Maybe this is a bug in `kombu` library

* 2. workers take too long: some tasks, e.g. android-lkft ones, may take a couple of minutes to process due to their gigantic number of tests. These fetch tasks might get picked by other workers before the first worker had finish it. 