### PR TITLE
Fifo queues

### DIFF
--- a/ansible/hosts.staging
+++ b/ansible/hosts.staging
@@ -1,10 +1,10 @@
 [webservers]
-staging-qa-reports-www-0 ansible_host=3.89.92.149 master_node=1
-staging-qa-reports-www-1 ansible_host=34.230.21.47
+staging-qa-reports-www-0 ansible_host=52.90.78.96 master_node=1
+staging-qa-reports-www-1 ansible_host=52.91.58.208
 [workers]
-staging-qa-reports-worker-0 ansible_host=34.238.41.123 worker_type=quick
-staging-qa-reports-worker-1 ansible_host=3.87.142.116
-staging-qa-reports-worker-2 ansible_host=18.204.202.155
+staging-qa-reports-worker-0 ansible_host=3.88.203.252 worker_type=quick
+staging-qa-reports-worker-1 ansible_host=3.88.113.180
+staging-qa-reports-worker-2 ansible_host=34.226.122.188
 [staging:children]
 webservers
 workers

--- a/ansible/roles/squad/templates/environment
+++ b/ansible/roles/squad/templates/environment
@@ -17,6 +17,7 @@ SQUAD_CELERY_BROKER_URL=amqp://{{master_hostname}}
 {% else %}
 SQUAD_CELERY_BROKER_URL=sqs://
 SQUAD_CELERY_QUEUE_NAME_PREFIX={{env}}_
+SQUAD_CELERY_QUEUE_NAME_SUFFIX=.fifo
 SQUAD_CELERY_POLL_INTERVAL=60
 {% endif %}
 SQUAD_BASE_URL=https://{{server_name}}

--- a/terraform/modules/sqs/sqs.tf
+++ b/terraform/modules/sqs/sqs.tf
@@ -14,8 +14,9 @@ variable "queue_names" {
 
 resource "aws_sqs_queue" "qa_reports_queue" {
   count = "${length(var.queue_names)}"
-  name  = "${var.environment}_${var.queue_names[count.index]}"
+  name  = "${var.environment}_${var.queue_names[count.index]}.fifo"
   visibility_timeout_seconds = "${var.visibility_timeout}"
+  fifo_queue = "true"
 }
 
 # Create an IAM policy and attach it to the environment role


### PR DESCRIPTION
Last week we had a lab outage that turned some lava backends offline for a couple of hours. Because of that, many `submit` tasks were failing and thus being added back to the queue ([celery retry strategy](https://docs.celeryproject.org/en/stable/userguide/tasks.html)).

The trick is that we were using standard queues in SQS, and here's a snippet from its documentation:

> Standard queues support at-least-once message delivery. However, occasionally (because of the highly distributed architecture that allows nearly unlimited throughput), more than one copy of a message might be delivered out of order[1]

Last Friday @mwasilew  and I ran a few tests in staging and we noticed exact copy of `submit` tasks being picked up by two workers. Because the outage lasted for a couple of hours, each hour would double the number of `submit` tasks in the queue. By the time the lab came back online, there were a lot of extra submissions sent to labs, thus causing things to be slow.

This PR uses FIFO queues, which guarantees that a message will be delivered to a worker only once:

> The order in which messages are sent and received is strictly preserved and a message is delivered once and remains available until a consumer processes and deletes it [2]

Today we tested things again using FIFO and all came back to normal.

[1] https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/standard-queues.html
[2] https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html