### PR TITLE
ansible: remove unused apache2 rewrite rules

### DIFF
--- a/ansible/roles/frontend/templates/apache2.conf
+++ b/ansible/roles/frontend/templates/apache2.conf
@@ -41,7 +41,5 @@
   RewriteRule ^/munin(.*) http://{{master_hostname}}/munin$1 [P,QSA,L]
   {% endif %}
 
-  RewriteRule ^/.well-known/acme-challenge/(.*) /var/lib/dehydrated/acme-challenges/$1 [QSA,L]
-  RewriteRule ^/.well-known/upgrade /usr/lib/cgi-bin/squad-upgrade-webhook [QSA,L,H=cgi-script]
   RewriteRule ^.*$ http://127.0.0.1:8000%{REQUEST_URI} [P,QSA,L]
 </VirtualHost>


### PR DESCRIPTION
There were two RewriteRules in apach2.conf that I didn't find their location in any production nor staging servers. I guess they're leftover configuration settings