### PR TITLE
Change squad image tag

### DIFF
--- a/k8s/qareports-fetch-worker.yml
+++ b/k8s/qareports-fetch-worker.yml
@@ -46,7 +46,7 @@ spec:
 
       containers:
       - name: qareports-fetch-worker
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["sh", "-c"]
         args:

--- a/k8s/qareports-fetch-worker.yml
+++ b/k8s/qareports-fetch-worker.yml
@@ -9,7 +9,7 @@ metadata:
 spec:
   minReplicas: 1
   maxReplicas: 10
-  targetCPUUtilizationPercentage: 50
+  targetCPUUtilizationPercentage: 20
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/k8s/qareports-listener.yml
+++ b/k8s/qareports-listener.yml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: qareports-listener
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["sh", "-c"]
         args:

--- a/k8s/qareports-migration.yml
+++ b/k8s/qareports-migration.yml
@@ -18,7 +18,7 @@ spec:
 
       containers:
       - name: qareports-migration
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["squad-admin"]
         args:

--- a/k8s/qareports-scheduler.yml
+++ b/k8s/qareports-scheduler.yml
@@ -27,7 +27,7 @@ spec:
 
       containers:
       - name: qareports-scheduler
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["sh", "-c"]
         args:

--- a/k8s/qareports-web.yml
+++ b/k8s/qareports-web.yml
@@ -103,7 +103,7 @@ spec:
     spec:
       initContainers:
       - name: init-qareports-web
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["cp", "-r", "/app/static", "/qareports_static"]
         volumeMounts:
@@ -138,7 +138,7 @@ spec:
             cpu: "500m"
 
       - name: qareports-web
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["sh", "-c"]
         args:

--- a/k8s/qareports-worker.yml
+++ b/k8s/qareports-worker.yml
@@ -53,7 +53,7 @@ spec:
 
       initContainers:
       - name: init-qareports-worker
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["sh", "-c", "cp /app/id_rsa /app/.ssh/id_rsa && chown -R squad:squad /app/.ssh && chmod 0600 /app/.ssh/id_rsa"]
         securityContext:
@@ -69,7 +69,7 @@ spec:
 
       containers:
       - name: qareports-worker
-        image: squadproject/squad
+        image: squadproject/squad:release
         imagePullPolicy: "Always"
         command: ["sh", "-c"]
         args:

--- a/qareports
+++ b/qareports
@@ -110,7 +110,7 @@ qareports_migrate_db() {
     if [ $# == 1 ]
     then
         image=$1
-        sed "s%squadproject/squad%\"$image\"%" k8s/qareports-migration.yml | k apply -f -
+        sed "s%squadproject/squad:release%\"$image\"%" k8s/qareports-migration.yml | k apply -f -
     else
         k apply -f k8s/qareports-migration.yml  # start job to apply migration, delete when finish
     fi


### PR DESCRIPTION
This PR changes the default squad image to squadproject/squad:release, this will prevent production from pulling latest images

It also lowers the CPU threshold of fetch-workers to 20% instead of 50% so that fetch-workers can autoscale more often (it's too difficult to reach 50%, 20% seems OK)