### PR TITLE
k8s: fetch-worker: increase memory limit for fetch worker

### DIFF
--- a/k8s/qareports-fetch-worker.yml
+++ b/k8s/qareports-fetch-worker.yml
@@ -67,5 +67,5 @@ spec:
             cpu: "2"
 
           limits:
-            memory: "4096M"
+            memory: "5120M"
             cpu: "2"


### PR DESCRIPTION
Fetch workers were getting killed due to oom errors, and their nodes got network all messed up. This memory increase will prevent pods from being restarted.