### PR TITLE
qareports: add run command

### DIFF
--- a/k8s/qareports-pod.yml
+++ b/k8s/qareports-pod.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: qareports-pod-name
+  labels:
+    app: qareports-pod
+spec:
+  containers:
+  - name: qareports-pod
+    image: squadproject/squad:release
+    imagePullPolicy: "Always"
+    command: ["sh", "-c"]
+    args:
+    - sleep infinity
+
+    envFrom:
+    - secretRef:
+        name: qareports-environment
+
+    resources:
+      requests:
+        memory: "8192M"
+        cpu: "4"
+
+      limits:
+        memory: "8192M"
+        cpu: "4"

--- a/qareports
+++ b/qareports
@@ -28,18 +28,19 @@ qareports_help() {
     echo "Usage: ./qareports $available_envs [command[args]]"
     echo
     echo "Commands:"
+    echo "  pods           show all pods"
+    echo "  upgrade_squad  upgrade SQUAD image in all deployments"
+    echo "  ssh node|pod   ssh into a node or a pod"
+    echo "  k              runs kubectl for k8s specific commands"
+    echo "  run            create a generic qareports pod (4cpu/8G) for admin commands"
     echo "  up             create the entire setup"
     echo "  destroy        destroy the entire setup"
     echo "  list           show all services (e.g. frontend, workers, etc)"
-    echo "  upgrade_squad  upgrade SQUAD image in all deployments"
     echo "  deploy         apply all configuration files"
     echo "  queues [-w]    show all queues"
-    echo "  pods           show all pods"
     echo "  top            show CPU and Memory usage in all pods"
-    echo "  ssh node|pod   ssh into a node or a pod"
     echo "  logs [-f] pod  display logs for a given pod, pass -f to keep following"
     echo "  dashboard      pop up a kubernetes dashboard"
-    echo "  k              runs kubectl for k8s specific commands"
     echo
     echo "Example:"
     echo "  $ ./qareports production upgrade_squad  # probably the most frequent command"
@@ -251,6 +252,25 @@ qareports_pods(){
 qareports_top(){
     echo "Showing pods' stats for $environment"
     k top pods
+}
+
+qareports_run(){
+    pod_name=qareports-pod-$USER
+    echo "Running generic qareports pod for adhoc commands. Delete them with './qareports $environment k delete pod $pod_name'"
+    sed s/qareports-pod-name/$pod_name/ k8s/qareports-pod.yml | k apply -f -
+
+    echo "Waiting for pod and node to be ready"
+    k wait --for=condition=ready --timeout=150s pod/$pod_name  # Wait 2 minutes for migration to complete
+    if [ $? != 0 ]
+    then
+        echo "Failed to start adhoc pod:"
+        k describe pod $pod_name
+        k delete pod $pod_name  # delete failed migration job
+        echo "*** ABORTING !!! ***"
+        exit 1
+    fi
+
+    k exec --stdin --tty $pod_name -- bash
 }
 
 qareports_logs(){


### PR DESCRIPTION
This allows admins to run commands on a pod with enough cpu and memory without ssh'ing to existing pods

`./qareports production run` will spin up a pod with 4cpu and 8G with all necessary environment variables to run admin commands in qareports production environment.