### PR TITLE
qareports-web: use /dev/shm for gunicorn tmp-dir

### DIFF
--- a/k8s/qareports-web.yml
+++ b/k8s/qareports-web.yml
@@ -142,7 +142,7 @@ spec:
         imagePullPolicy: "Always"
         command: ["sh", "-c"]
         args:
-        - squad --timeout=60 --workers=8 --fast --log-level DEBUG
+        - squad --timeout=60 --workers=8 --fast --log-level DEBUG --worker-tmp-dir /dev/shm
 
         envFrom:
         - secretRef:


### PR DESCRIPTION
Ref: https://pythonspeed.com/articles/gunicorn-in-docker/

@mwasilew I applied this to testing but didn't really feel much difference :/ 