### PR TITLE
shared: add ci-endpoint server

### DIFF
--- a/terraform/scripts/ci_endpoint_server.py
+++ b/terraform/scripts/ci_endpoint_server.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+"""
+    This script runs a simple flask app that servers only the index page
+    and expect a token to validate requests.
+
+    It's meant to be notified by dockerhub via webhook:
+    https://docs.docker.com/docker-hub/webhooks/
+
+    Dockerhub will trigger a request on every image built. This server receives
+    that request, check if image tag is "testing" or "latest" and update the
+    qareports environment equivalent.
+
+    At last, this server will send results of the upgrade back to dockerhub, for
+    further debugging if needed.
+"""
+
+import flask
+import os
+import requests
+import subprocess
+import sys
+
+
+# Flask app
+app = flask.Flask(__name__)
+
+
+# Token to check to validate incoming requests
+endpoint_token = None
+
+
+# Expected tags -> environment
+expected_tags = {
+    'testing': 'testing',
+    'latest': 'staging'
+}
+
+
+# qa-reports' root directory
+qareports_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../..')
+
+
+HTTP_ERROR = 401
+
+
+testing = False
+
+
+os.environ['KUBECONFIG'] = '/home/ubuntu/.kube/config'
+
+
+# Send callback to docker hub
+def send_callback(url, state, message):
+    if url is not None and url.startswith('https://registry.hub.docker.com'):
+        requests.post(url, json={'state': state, 'description': message})
+    else:
+        print('callback url "%s" is None or does not belong to docker hub' % url)
+
+
+# Serve only to index
+@app.route('/', methods=['POST'])
+def index():
+    token = flask.request.args.get('token')
+    if token is None or token != endpoint_token:
+        print('missing token')
+        return 'token missing or not matched', HTTP_ERROR
+
+    tag = flask.request.json.get('push_data')['tag']
+    if tag is None or expected_tags.get(tag) is None:
+        print('tag is unexpected')
+        return 'tag "%s" is unexpected' % tag, HTTP_ERROR
+
+    callback_url = flask.request.json.get('callback_url')
+
+    proc = subprocess.run(['git', 'pull', 'origin', 'master'])
+    if proc.returncode != 0:
+        print(message)
+        message = 'Failed to pull from git repository'
+        send_callback(callback_url, 'error', message)
+        return message, HTTP_ERROR
+
+    env = expected_tags.get(tag)
+    namespace = 'qareports-%s' % env
+    proc = subprocess.run(['./qareports', env, 'upgrade_squad'], env=os.environ)
+    if proc.returncode != 0:
+        message = 'Failed to upgrade %s. See logs for details' % env
+        print(message)
+        send_callback(callback_url, 'error', message)
+        return message, HTTP_ERROR
+
+    message = 'ok'
+    send_callback(callback_url, 'success', message)
+    return message
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage %s endpoint-token' % sys.argv[0])
+        sys.exit(-1)
+
+    endpoint_token = sys.argv[1]
+    if endpoint_token is None or len(endpoint_token) < 2:
+        print('endpoint-token is mandatory and should have at least 2 characters')
+        sys.exit(-2)
+
+    os.chdir(qareports_dir)
+
+    app.run(host='0.0.0.0')

--- a/terraform/scripts/endpoint_config.sh
+++ b/terraform/scripts/endpoint_config.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# NOTE: keep `region us-east-1 and  name QAREPORTS_EKSCluster` in sync with shared/variables.tf with respective values of "cluster_name" and "region"
+EKS_CLUSTER_NAME=QAREPORTS_EKSCluster
+EKS_CLUSTER_REGION=us-east-1
+
+
+# Endpoint settings
+EP_USER=ubuntu
+EP_DNS=ci-endpoint-qa-reports.ctt.linaro.org
+EP_TOKEN=$(openssl rand -hex 16)
+EP_SERVER=ci_endpoint_server
+EP_SERVER_SCRIPT=/home/ubuntu/qa-reports.linaro.org/terraform/scripts/$EP_SERVER.py
+EP_WWW_DIR=/var/www/$EP_SERVER
+EP_ADMIN_EMAIL=charles.oliveira@linaro.org
+
+
+# Add certbot's repository for generating https certificates
+add-apt-repository -y ppa:certbot/certbot
+
+
+# Get a few requirements
+apt update -qy && apt install -qy unzip libffi-dev python3-pip openssl wget git python-certbot-apache apache2 && su - $EP_USER -c "pip3 install flask requests"
+
+
+# Install awscli
+awscli=/tmp/awscliv2.zip
+wget -q "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -O "$awscli"
+chown $EP_USER:$EP_USER $awscli
+su - $EP_USER -c "unzip -q $awscli && sudo ./aws/install"
+
+
+# Get kubeconfig
+su - $EP_USER -c "aws eks update-kubeconfig --region $EKS_CLUSTER_REGION --name $EKS_CLUSTER_NAME"
+
+
+# Get kubectl
+kubectl_url="https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl"
+kubectl_tmp=/tmp/kubectl
+wget -q $kubectl_url -O $kubectl_tmp
+chmod +x $kubectl_tmp && mv $kubectl_tmp /usr/local/bin/kubectl
+
+
+# Get a copy of qareports deploy scripts
+su - $EP_USER -c "git clone https://github.com/chaws/qa-reports.linaro.org"
+
+
+# Make the endpoint a service
+cat > /etc/systemd/system/ci_endpoint_server.service <<EOF
+[Unit]
+Description=Endpoint server to upgrade testing and staging environments
+
+[Service]
+User=$EP_USER
+Group=$EP_USER
+Restart=always
+RestartSec=5
+ExecStart=$EP_SERVER_SCRIPT $EP_TOKEN
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl start ci_endpoit_server
+systemctl enable ci_endpoit_server
+
+
+# Configure apache virtual host
+mkdir -p $EP_WWW_DIR && chown -R $EP_USER:$EP_USER $EP_WWW_DIR && chmod -R 755 $EP_WWW_DIR
+
+cat > /etc/apache2/sites-available/$EP_SERVER.conf <<EOF
+<VirtualHost *:80>
+    ServerName $EP_DNS
+    DocumentRoot $EP_WWW_DIR
+    RewriteEngine On
+    RewriteCond %{HTTPS}  !=on
+    RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
+</VirtualHost>
+EOF
+
+cat > /etc/apache2/sites-available/$EP_SERVER-le-ssl.conf <<EOF
+<VirtualHost *:443>
+    ServerName $EP_DNS
+    ServerAlias $EP_DNS
+    DocumentRoot $EP_WWW_DIR
+    RewriteEngine On
+    ProxyPreserveHost On
+    ProxyPass "/" http://127.0.0.1:5000/
+    <Directory $EP_WWW_DIR>
+        Options -Indexes
+    </Directory>
+    SSLCertificateFile /etc/letsencrypt/live/$EP_DNS/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/$EP_DNS/privkey.pem
+    Include /etc/letsencrypt/options-ssl-apache.conf
+</VirtualHost>
+
+EOF
+
+a2enmod rewrite
+a2enmod proxy
+a2enmod proxy_http
+a2enmod proxy_balancer
+a2enmod lbmethod_byrequests
+a2ensite $EP_SERVER.conf
+a2dissite 000-default.conf
+systemctl restart apache2
+
+certbot --non-interactive --agree-tos -m $EP_ADMIN_EMAIL --apache -d $EP_DNS

--- a/terraform/scripts/test_ci_endpoint_server.py
+++ b/terraform/scripts/test_ci_endpoint_server.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+"""
+    This script tests "ci_endpoint_server.py"
+
+    Requirements:
+    * generate random token:
+      $ TOKEN=$(openssl rand -hex 16)
+
+    * start up the ci endepoint server:
+      $ ./ci_endpoint_server.py $TOKEN
+
+    * run this script:
+      $ ./test_ci_endpoint_server.py $TOKEN
+"""
+
+
+import sys
+from requests import post, packages
+
+
+# ref: https://github.com/influxdata/influxdb-python/issues/240#issuecomment-140003499
+packages.urllib3.disable_warnings()
+
+
+def main():
+    if len(sys.argv) != 2:
+        print('Usage: %s token' % sys.argv[0])
+        sys.exit(-1)
+
+    token = sys.argv[1]
+    url = 'https://localhost:5000?token=%s'
+
+    # Test missing/invalid token
+    r = post(url % '', json={}, verify=False)
+    assert r.status_code == 401, 'response is not 401 for empty/invalid token: %s' % r.text
+
+    url = url % token
+
+    # Test missing/invalid tag
+    r = post(url, json={}, verify=False)
+    assert r.status_code == 401, 'response is not 401 for empty tag: %s' % r.text
+    r = post(url, json={'tag': 'weird-tag'}, verify=False)
+    assert r.status_code == 401, 'response is not 401 for invalid tag: %s' % r.text
+
+    # Test successfull
+    r = post(url, json={'tag': 'testing'}, verify=False)
+    assert r.status_code == 200, 'response is not 200 for testing tag: %s' % r.text
+
+    print('passed!')
+
+if __name__ == '__main__':
+    main()

--- a/terraform/shared/endpoint.tf
+++ b/terraform/shared/endpoint.tf
@@ -1,0 +1,94 @@
+#
+#   CI Endpoint instance to allow triggering updates in staging and testing environments
+#   via webhooks
+#
+resource "aws_security_group" "qareports_ci_endpoint_instance_security_group" {
+    name = "QAREPORTS_CIEndpointSecurityGroup"
+    description = "Allow traffic thru port 443"
+    vpc_id = "${aws_vpc.qareports_vpc.id}"
+
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    ingress {
+        from_port = 443
+        to_port = 443
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    ingress {
+        from_port = 22
+        to_port = 22
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    ingress {
+        from_port = -1
+        to_port = -1
+        protocol = "icmp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    egress {
+        from_port = 443
+        to_port = 443
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    egress {
+        from_port = 22
+        to_port = 22
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    egress {
+        from_port = -1
+        to_port = -1
+        protocol = "icmp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+# Create an instance profile to attach QAREPORTS_EKSCIRole (eks.tf) to CI Endpoint instance
+resource "aws_iam_instance_profile" "qareports_ci_endpoint_instance_profile" {
+    name = "QAREPORTS_CIEndpointInstanceProfile"
+    role = "${aws_iam_role.qareports_eks_ci_role.name}"
+}
+
+resource "aws_instance" "qareports_ci_endpoint_instance" {
+    tags = {
+        Name = "QAREPORTS_CIEndpoint"
+    }
+    ami = "${var.ami_id}"
+    instance_type = "t3a.nano"
+    key_name = "${aws_key_pair.qareports_ssh_key.key_name}"
+    vpc_security_group_ids = ["${aws_security_group.qareports_ci_endpoint_instance_security_group.id}"]
+    associate_public_ip_address = true
+
+    # Place instance in a public subnet
+    subnet_id = "${aws_subnet.qareports_public_subnet_1.id}"
+    availability_zone = "${aws_subnet.qareports_public_subnet_1.availability_zone}"
+
+    # Place a flask app to respond webhook requests
+    user_data = "${file("${path.module}/../scripts/endpoint_config.sh")}"
+
+    # Attach role
+    iam_instance_profile = "${aws_iam_instance_profile.qareports_ci_endpoint_instance_profile.name}"
+}
+
+resource "aws_route53_record" "qareports_ci_endpoint_dns" {
+    zone_id = "${var.route53_zone_id}"
+    name = "${var.ci_endpoint_url}"
+    type = "A"
+    ttl = 300
+    records = ["${aws_instance.qareports_ci_endpoint_instance.public_ip}"]
+}

--- a/terraform/shared/output.tf
+++ b/terraform/shared/output.tf
@@ -27,6 +27,7 @@ data "template_file" "shared_vars" {
     vpc_id               = "${aws_vpc.qareports_vpc.id}"
     vpc_cidr             = "${aws_vpc.qareports_vpc.cidr_block}"
     region               = "${var.region}"
+    route53_zone_id      = "${var.route53_zone_id}"
     ssh_key_name         = "${aws_key_pair.qareports_ssh_key.key_name}"
     eks_cluster_name     = "${aws_eks_cluster.qareports_eks_cluster.name}"
     public_subnet1_id    = "${aws_subnet.qareports_public_subnet_1.id}"

--- a/terraform/shared/variables.tf
+++ b/terraform/shared/variables.tf
@@ -12,3 +12,13 @@ variable "region" {
     type = "string"
     default = "us-east-1"
 }
+
+variable "ci_endpoint_url" {
+    type = "string"
+    default = "ci-endpoint-qa-reports.ctt.linaro.org"
+}
+
+variable "route53_zone_id" {
+    type = "string"
+    default = "Z27NRA2FV79C84"
+}

--- a/terraform/shared/vpc.tf
+++ b/terraform/shared/vpc.tf
@@ -251,12 +251,6 @@ resource "aws_security_group" "qareports_nat_instance_security_group" {
     }
 }
 
-# Create an instance profile to attach QAREPORTS_EKSStagingCIRole to NAT instance so that ci.linaro.org can update staging pods
-resource "aws_iam_instance_profile" "qa_reports_nat_instance_profile" {
-    name = "QAREPORTS_NATInstanceProfile"
-    role = "${aws_iam_role.qareports_eks_staging_ci_role.name}"
-}
-
 resource "aws_instance" "qareports_nat_instance" {
     tags = {
         Name = "QAREPORTS_NAT"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,14 +18,9 @@ variable "db_max_storage"       { type = "string" }
 variable "db_name"              { type = "string" }
 variable "db_username"          { type = "string" }
 variable "db_password"          { type = "string" }
-
-variable "route53_zone_id" {
-    type = "string"
-    default = "Z27NRA2FV79C84"
-}
-
-variable "canonical_dns_name" { type = "string" }
-variable "dns_name" { type = "string" }
+variable "route53_zone_id"      { type = "string" }
+variable "canonical_dns_name"   { type = "string" }
+variable "dns_name"             { type = "string" }
 variable "dns_validation_method" { type = "string" }
 
 data "aws_eks_cluster" "qareports_eks_cluster" {


### PR DESCRIPTION
This will allow external services to communicate with qa-reports, e.g. dockerhub can trigger testing and staging updates when new
images become available.

A manual step was necessary: need to add the code snippet below to aws-auth configmap in eks
```
    - groups:
      - system:masters
      rolearn: arn:aws:iam::<aws account number>:role/QAREPORTS_EKSCIRole
      username: QAREPORTS_EKSCIRole
```

I did it manually because I don't know yet how to do it in terraform. Will tackle that when allowing pods to access S3