### PR TITLE
k8s: [fetch-]worker: increase grace period to 1h

### DIFF
--- a/k8s/qareports-fetch-worker.yml
+++ b/k8s/qareports-fetch-worker.yml
@@ -39,6 +39,7 @@ spec:
         app: qareports-fetch-worker
 
     spec:
+      terminationGracePeriodSeconds: 3600
       serviceAccount: qareports-serviceaccount
       securityContext:
         fsGroup: 0

--- a/k8s/qareports-worker.yml
+++ b/k8s/qareports-worker.yml
@@ -39,6 +39,7 @@ spec:
         app: qareports-worker
 
     spec:
+      terminationGracePeriodSeconds: 3600
       serviceAccount: qareports-serviceaccount
       securityContext:
         fsGroup: 0


### PR DESCRIPTION
K8s sends `SIGTERM` to `Running` pods during an image update or scaling down event. SIGTERM is forwarded containers in these pods then they immediately jump to `Terminating` state where a default grace period of `30` seconds kicks in. This "timeout" (sort of) is the time that the main process in these containers have to finish their thing and exit. After the grace period runs out, K8s sends a `SIGKILL` and removes the pod by force.

In our case, some tasks like fetching android-lkft jobs might take longer than 30 seconds so it's imperative that they don't receive `SIGKILL`. With recently implementation of `celery-chords` by @mwasilew the longest running task we imagine will take at most 15min to ends its processing. Having that in mind, I picked a grace period of `1 hour` just to be safe.

Pods with grace period of 1h running a task that takes 15min will exit within these 15min.

Please note that tasks that take longer than 1h and fell in those two categories (during an event of update or scaling down) might lose data.